### PR TITLE
Fixed Typo for 'Containerization'

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         There are other articles not currently under construction which we would like to add the LandChad.net.
         If you have experience with any of these, you may submit an article for review on <a href="https://github.com/lukesmithxyz/landchad">the Github</a>.
         Please include directions for Debian 10 as default.
-        Abstain from using containization.
+        Abstain from using containerization ( Docker, etc ).
         Attempt to follow the same settings as other articles here.
         </p>
 


### PR DESCRIPTION
Fixed typo for word 'containerization' and mentioned Docker as an example of what not to use when adding a tutorial/guide.