### PR TITLE
Added styling for a "callout" style aside and also added a bit on ssh key file permissions

### DIFF
--- a/sshkeys.html
+++ b/sshkeys.html
@@ -76,6 +76,7 @@
         </p>
         </aside>
 
+
         <p>
         To test if this has worked, now try logging in normally to your server with ssh:
         </p>
@@ -85,6 +86,22 @@
         <p>
         It should now let your log in without a password prompt!
         </p>
+        <aside class=callout>
+            <p>
+            If you find that this does not work try running the following, make sure you are in the directory where the keys where created. 
+            </p>
+            <p>
+            <code> chmod 700 .ssh/ </code>
+            </p>
+            <code> chmod 644 .ssh/id_rsa.pub </code>
+            <p>
+            <code> chmod 600 .ssh/id_rsa </code>
+            </p>
+            <code> chmod 644 .ssh/authorized_keys </code>
+            <p>
+            For whatever reason these files due not have the correct permissions set, as ssh is very picky about correct file permissions this can cause errors. The above will fix these.
+            </p>
+        </aside>
 
         <h2>Disabling Password Logins for Security</h2>
 

--- a/sshkeys.html
+++ b/sshkeys.html
@@ -76,7 +76,6 @@
         </p>
         </aside>
 
-
         <p>
         To test if this has worked, now try logging in normally to your server with ssh:
         </p>

--- a/style.css
+++ b/style.css
@@ -126,10 +126,18 @@ aside code {
     color: green ;
 }
 
+/* .callout here is refencing any aside given the class name callout
+ * An example being: <aside class="callout"> */
+aside.callout  {
+    border: solid 1px orange;
+}
+
+
 .cnp {
 	width: 100% ;
 
 }
+
 
 /* This "@media" block defines rules that will only be applied when the minimum
  * width of the screen is 55em or greater. In essence, they are settings that

--- a/style.css
+++ b/style.css
@@ -132,12 +132,10 @@ aside.callout  {
     border: solid 1px orange;
 }
 
-
 .cnp {
 	width: 100% ;
 
 }
-
 
 /* This "@media" block defines rules that will only be applied when the minimum
  * width of the screen is 55em or greater. In essence, they are settings that


### PR DESCRIPTION
I think a "callout" style thing is useful for a type of aside with information containing fixes for common errors. The only difference with a normal aside is that the border colour is orange. 

I've also added a callout aside about ssh key file permissions which I find to be a very common issue, to diagnose this normally requires viewing log files which could be overwhelming. The fix is always the same which is running the commands I added.

Appreciate that those should be 2 seperate PRs but they went hand in hand. 

