### PR TITLE
Updated tor guide

### DIFF
--- a/tor.html
+++ b/tor.html
@@ -25,9 +25,20 @@
 
         <h2>Setting up Tor</h2>
 
-        <p>First, install tor. On Debian it's as simple as:</p>
+        <p>Firstly we need to add the tor repo's to have the latest up to date version or tor.</p>
 
-        <pre><code> apt install tor</code></pre>
+        <pre><code>echo "deb https://deb.torproject.org/torproject.org buster main" > /etc/apt/sources.list.d/</code></pre>
+	<pre><code>echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/</code></pre>
+	    
+	<p>Then we need to add the gpg keys to our keyring</p>
+	
+	<pre><code>curl https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import</code></code>
+	<pre><code>gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -</code></code>
+	    
+	<p>Now update and install tor</p>
+	
+	<pre><code>apt update</code></pre>
+	<pre><code>apt install tor deb.torproject.org-keyring</code></pre>
 
         <p>Then edit the file <code>/etc/tor/torrc</code>, uncommenting the following lines:</p>
         <pre><code>        HiddenServiceDir /var/lib/tor/hidden_service/
@@ -72,6 +83,10 @@
         <p>
         From here we are almost done, all we have to do is enable the site and reload nginx which is also covered in <a href="nginx.html#enable">the webserver tutorial</a>.
         </p>
+	<p> Also make sure to update tor on a regular basis by running</p>
+        <pre><code>apt update</code></pre>
+	<pre><code>apt install tor</code></pre>
+	 
         <strong>Contributor</strong>  -  <a href="https://tomfasano.xyz" target="_blank">tomfasano.xyz</a>
 
     </main>

--- a/tor.html
+++ b/tor.html
@@ -26,7 +26,7 @@
         <h2>Setting up Tor</h2>
 
         <p>Firstly we need to add the tor repo's to have the latest up to date version or tor.</p>
-
+        <pre><code>apt install apt-transport-https</code></pre>
         <pre><code>echo "deb https://deb.torproject.org/torproject.org buster main" > /etc/apt/sources.list.d/</code></pre>
 	<pre><code>echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/</code></pre>
 	    

--- a/tor.html
+++ b/tor.html
@@ -27,8 +27,8 @@
 
         <p>Firstly we need to add the tor repo's to have the latest up to date version or tor.</p>
         <pre><code>apt install apt-transport-https</code></pre>
-        <pre><code>echo "deb https://deb.torproject.org/torproject.org buster main" > /etc/apt/sources.list.d/</code></pre>
-	<pre><code>echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/</code></pre>
+        <pre><code>echo "deb https://deb.torproject.org/torproject.org buster main" > /etc/apt/sources.list.d/tor</code></pre>
+	<pre><code>echo "deb-src https://deb.torproject.org/torproject.org buster main" >> /etc/apt/sources.list.d/tor</code></pre>
 	    
 	<p>Then we need to add the gpg keys to our keyring</p>
 	


### PR DESCRIPTION
Tor is something you have to keep up to date, and debian has very outdated packages. It is pretty trivial to add an updated version of tor to your setup. I got the instructions [here](https://2019.www.torproject.org/docs/debian.html.en)