### PR TITLE
properly avoid reuploading non-modified files

### DIFF
--- a/rsync.html
+++ b/rsync.html
@@ -20,14 +20,14 @@
 <pre><code>apt install rsync</code></pre>
 <h2 id="uploading-files-with-rsync">Uploading files with rsync</h2>
 <p>From your local machine you can upload files to your server like this:</p>
-<pre><code>rsync -ruvzP <strong>/path/to/file</strong> <strong>root@example.org:/path/on/the/server</strong></code></pre>
+<pre><code>rsync -rtvzP <strong>/path/to/file</strong> <strong>root@example.org:/path/on/the/server</strong></code></pre>
 <p>You will be prompted for the root password and then uploading will commence.</p>
 <p>If you omit <strong>root@</strong>, rsync will not attempt to log in as root, but whatever your local username is.</p>
 <h3>Options to rsync</h3>
 <p>In this command, we give several options to rsync:</p>
 <ul>
     <li><code>-r</code> &ndash; run recurssively (include directories)</li>
-    <li><code>-u</code> &ndash; update files (do not reupload files that are not changed since last upload)</li>
+    <li><code>-t</code> &ndash; transfer modification times, which allows skipping files that have not been modified on future uploads</li>
     <li><code>-v</code> &ndash; visual, show files uploaded</li>
     <li><code>-z</code> &ndash; compress files for upload</li>
     <li><code>-P</code> &ndash; if uploading a large file and upload breaks, pick up where we left off rather than reuploading the entire file</li>
@@ -39,14 +39,14 @@
 <p>To avoid having to manually input your password each upload, you can set up <a href="sshkeys.html">SSH keys</a> to securely idenitify yourself and computer as a trusted.</p>
 <h3>Picky trailing slashes</h3>
 <p>rsync is very particular about trailing slashes. This is useful, but can be confusing to some new users. Suppose we run the following wanting to mirror our offline copy of our website in the directory we use on our server (<code>/var/www/websitefiles/</code>):</p>
-<pre><code>rsync -ruvzP ~/<strong>websitefiles/</strong> root@example.org:/var/www/<strong>websitefiles/</strong></code></pre>
+<pre><code>rsync -rtvzP ~/<strong>websitefiles/</strong> root@example.org:/var/www/<strong>websitefiles/</strong></code></pre>
 <p>This will <em>not actually do quite what we want</em>. It will take our local <code>websitefiles</code> directory and put it <em>inside</em> <code>websitefiles</code> on the remote machine, ending up with: <code>/var/www/websitefiles/websitefiles</code>.</p>
 <p>Instead, remove the trailing slash from the remote server location:</p>
-<pre><code>rsync -ruvzP ~/<strong>websitefiles/</strong> root@example.org:/var/www/<strong>websitefiles</strong></code></pre>
+<pre><code>rsync -rtvzP ~/<strong>websitefiles/</strong> root@example.org:/var/www/<strong>websitefiles</strong></code></pre>
 <p><code>websitefiles/</code> has been replaced with <code>websitefiles</code>, and this will do what we want.</p>
 <h2 id="downloading-file-with-rsync">Downloading files with rsync</h2>
 <p>You may just as easily download files and directories from your server with rsync:</p>
-<pre><code>rsync -urvzP <strong>root@example.org:/path/to/file</strong> <strong>/path/to/file</strong></code></pre>
+<pre><code>rsync -rtvzP <strong>root@example.org:/path/to/file</strong> <strong>/path/to/file</strong></code></pre>
 <h2 id="contribution">Contribution</h2>
 <ul><li>el3ctr0lyte: <a href="https://github.com/el3ctr0lyte">github</a>, XMR: <code class=crypto>86DBJdiG83ZDea6kJgsbVN5tMae5ScfuhJ3PihEMTHatCrGEw2gctyUB92V2fz4R4YhwRaQeAGL5M4gPRXvVvtkULJi4ayk</code></li><li>Substantial revisions by <a href="https://lukesmith.xyz">Luke</a></li></ul>
 </main>


### PR DESCRIPTION
-u does not avoid reuploading files that haven't been changed since the
last upload. That is the default behavior and can only disabled with
--ignore-times, -I. But for that to work, you need transfer modification
times with -t.

What -u does is skip uploading files that have a newer modified time on
the DESTINATION, which is not something that you commonly need. For
example, if you store translation strings in files, and both you and the
website owner modify them, you can use -u to ensure that you don't
overwrite newer translation files on the server when you upload, without
having to remember to download new changes before every upload. They
would otherwise be overwritten even if you haven't modified your local
files lately.

If you don't transfer the modification times, the versions on the
destination will have the modified time of the upload which is newer
than the last time they were modified locally, and so -u will skip
uploading them because they are newer on the receiver, but it's not
meant to be used for that. You should normally just use -t.

With -u you also risk that if the files on the server have been modified
for some reason after their local counterparts, they won't be updated on
uploads.