### PR TITLE
Fix nextcloud https redirect

### DIFF
--- a/nextcloud.html
+++ b/nextcloud.html
@@ -52,9 +52,7 @@ server {
     listen [::]:80;
     server_name <strong>yourwebsite.com</strong>;
 
-    location /nextcloud {
-        return 301 https://$server_name$request_uri;
-    }
+    return 301 https://$server_name$request_uri;
 }
 
 server {


### PR DESCRIPTION
In the provided nginx server configuration for nextcloud, http
connections don't always redirect to https, so this was fixed.