### PR TITLE
Updated PeerTube guide

### DIFF
--- a/peertube.html
+++ b/peertube.html
@@ -65,9 +65,15 @@ exit</code></pre>
 	<pre><code>sudo -u peertube mkdir config storage versions
 sudo -u peertube chmod 750 config</code></pre>
 
-	<p>Finally, a PeerTube release can be downloaded from the GitHub page and installed using yarn:</p>
+	<p>Finally, a PeerTube release can be downloaded from the GitHub page using the <code>VERSION</code> variable from before:</p>
 
-	<pre><code>cd versions
+        <pre><code>cd /var/www/peertube/versions
+sudo -u peertube wget -q "https://github.com/Chocobozzz/PeerTube/releases/download/${VERSION}/peertube-${VERSION}.zip"
+sudo -u peertube unzip -q peertube-${VERSION}.zip && sudo -u peertube rm peertube-${VERSION}.zip</code></pre>
+
+<p>The downloaded release can then be symbolically linked to <code>/var/www/peertube/peertube-latest</code> and <strong>yarn</strong> is used to install PeerTube:</p>	
+
+<pre><code>
 sudo -u peertube ln -s versions/peertube-${VERSION} ./peertube-latest
 cd ./peertube-latest && sudo -H -u peertube yarn install --production --pure-lockfile</code></pre>
 


### PR DESCRIPTION
I added some clarification in the downloads section and fixed an error where there was no guide as to how to actually download PeerTube from the releases