### PR TITLE
Remove .html extensions from urls

### DIFF
--- a/nginx.html
+++ b/nginx.html
@@ -147,7 +147,7 @@ will be the main page of our website.
 </p>
 <p>
 Lastly, the <code>location</code> block is really just telling the server how to look up files, otherwise throw a 404 error.
-Location settings are very powerful, but this is all we need them for now.
+The <code>if</code> directive is telling <code>nginx</code> to run a regex on the <code>$request_uri</code> portion of incoming requests, and remove the <code>.html</code> extension.
 </p>
 </aside>
 

--- a/nginx.html
+++ b/nginx.html
@@ -115,7 +115,10 @@ apt install nginx</code></pre>
         root /var/www/<strong>landchad</strong> ;
         index index.html index.htm index.nginx-debian.html ;
         location / {
-                try_files $uri $uri/ =404 ;
+		if ($request_uri ~ ^/(.*)\.html) {
+			return 302 /$1;
+		}
+                try_files $uri $uri.html $uri/ =404 ;
         }
 }</code></pre>
 


### PR DESCRIPTION
Remove the .html extension from every url by telling NGINX to run a regex on incoming requests.

This is probably something everyone will try to figure out how to do anyway.