### PR TITLE
Jitsi: Changed cert.pem to fullchain.pem

### DIFF
--- a/jitsi.html
+++ b/jitsi.html
@@ -90,7 +90,7 @@ ufw enable</code></pre>
       <p>
         When it ask you for the certification key and cert files, input
         <code>/etc/letsencrypt/live/<strong>meet.example.org</strong>/privkey.pem</code> and
-        <code>/etc/letsencrypt/live/<strong>meet.example.org</strong>/cert.pem</code> respectively.
+        <code>/etc/letsencrypt/live/<strong>meet.example.org</strong>/fullchain.pem</code> respectively.
       </p>
 
       <h2>Using Jitsi</h2>


### PR DESCRIPTION
The full chain cert is required for the Android app and some browsers to connect to the server