### PR TITLE
Fix typo on OpenAlias

### DIFF
--- a/openalias.html
+++ b/openalias.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang=en>
     <head>
-        <title>Open Alias &ndash; LandChad.net</title>
+        <title>OpenAlias &ndash; LandChad.net</title>
         <meta charset="utf-8"/>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
         <link rel='stylesheet' type='text/css' href='style.css'>
@@ -9,7 +9,7 @@
     <link rel='alternate' type='application/rss+xml' title='Land Chad RSS' href='/rss.xml'>
     </head>
 <body>
-    <header><h1>Open Alias</h1></header>
+    <header><h1>OpenAlias</h1></header>
     <nav></nav>
     <main>
 


### PR DESCRIPTION
This pull request fixes the typo on OpenAlias page, OpenAlias is not "Open Alias" as the official name doesn't include a space between Open and Alias, small minor change but it should be done.