### PR TITLE
Add firewall note to TOR guide

### DIFF
--- a/tor.html
+++ b/tor.html
@@ -56,6 +56,9 @@ HiddenServicePort 80 127.0.0.1:80</code></pre>
 
         <p>If the next command outputs <q>active</q> in green you're golden!</p>
         <pre><code> systemctl status tor</code></pre>
+	
+        <p>Finally, if you have a firewall running, remember to open port 9050:</p>
+        <pre><code>ufw allow 9050</code></pre>
 
         <p>Now your server is on the dark web. The following command will give you your onion address:</p>
         <pre><code> cat /var/lib/tor/hidden_service/hostname</code></pre>


### PR DESCRIPTION
I added a note to the TOR guide to open the firewall port used by TOR (ran into this myself).