### PR TITLE
Remove the allow port 9050 instruction

### DIFF
--- a/tor.html
+++ b/tor.html
@@ -56,11 +56,8 @@ HiddenServicePort 80 127.0.0.1:80</code></pre>
 
         <p>If the next command outputs <q>active</q> in green you're golden!</p>
         <pre><code> systemctl status tor</code></pre>
-	
-        <p>Finally, if you have a firewall running, remember to open port 9050:</p>
-        <pre><code>ufw allow 9050</code></pre>
-
-        <p>Now your server is on the dark web. The following command will give you your onion address:</p>
+	   
+	   <p>Now your server is on the dark web. The following command will give you your onion address:</p>
         <pre><code> cat /var/lib/tor/hidden_service/hostname</code></pre>
 
         <h2>Adding the Nginx Config</h2>


### PR DESCRIPTION
It is not necessary to forward or allow any port to host hidden
services in Tor. The `127.0.0.1:9050` is only the SOCKS Proxy port,
which has nothing to do with onion services hosting.