### PR TITLE
Suggestion: Autodetect CPU arch for non amd64 users (e.g aarch64/arm64)

### DIFF
--- a/gitea.html
+++ b/gitea.html
@@ -27,7 +27,7 @@
 
         <p>Then add the actual repository to apt:</p>
 
-        <pre><code>echo "deb [arch=amd64] https://packaging.gitlab.io/gitea gitea main" > /etc/apt/sources.list.d/morph027-gitea.list</code></pre>
+        <pre><code>echo "deb [arch=$(dpkg --print-architecture)] https://packaging.gitlab.io/gitea gitea main" > /etc/apt/sources.list.d/morph027-gitea.list</code></pre>
 
         <p>Now we can install Gitea:<p>
 


### PR DESCRIPTION
"Keep It Stupid Simple" "noob friendly" material?

+ win win for those who copy paste
- more stuff to type out for those who do the "old school way"
- possibility of uncommon architecture which gitea might not support yet.