### PR TITLE
SSH config and ed25519

### DIFF
--- a/content/sshkeys.md
+++ b/content/sshkeys.md
@@ -28,7 +28,7 @@ having to input your password each time you touch the server.
 Generating an SSH key is simple. Just run:
 
 ```sh
-ssh-keygen
+ssh-keygen -t ed25519 -b 4096
 ```
 
 It will prompt you for several options and you can generally chose the

--- a/content/sshkeys.md
+++ b/content/sshkeys.md
@@ -55,6 +55,23 @@ I suggest copying your entire `~/.ssh/` directory (user-specific) to a
 USB drive and storing it securely. You may also copy it to the same
 place on another computer to use the key there.
 
+## Automatically use your key to log in
+
+Now that you've set up your ssh key, you need to tell ssh to actually use it. 
+
+Edit `~/.ssh/config` and create a block like this:
+
+```
+Host yourdomain.com
+    User your-server-username
+    IdentityFile ~/.ssh/nameofyourkey
+```
+
+This will tell ssh the default username and ssh key to send when 
+connecting to your server.
+
+For more information, you can see `man 5 SSH_CONFIG`
+
 ## Making your server trust your key.
 
 Now that you have generated an SSH key, just run the following:


### PR DESCRIPTION
Including basic directions for ssh config, so users don't need to specify -i if they don't choose a default key name.

Create ed25519 key rather than (default) RSA because nearly all systems now support it and it's a better algorithm.