### PR TITLE
Update call to htpasswd to specify bcrypt

### DIFF
--- a/content/radicale.md
+++ b/content/radicale.md
@@ -46,7 +46,7 @@ As you can see under \[auth\] we use htpasswd to manage the users.
 Execute the following command to add a new user to Radicale.
 
 ```sh
-htpasswd -c /etc/radicale/users username
+htpasswd -B -c /etc/radicale/users username
 ```
 
 As Radicale stands now it is fully functional and after starting it by


### PR DESCRIPTION
A recent change updated the htpasswd encryption scheme to bcrypt, but the call to htpasswd wasn't updated, which caused radicale to crash:

```
Jun 30 16:12:38 platinum radicale[2695]: RuntimeError: Invalid htpasswd file '/etc/radicale/users': not a valid bcrypt hash 
```

This updates the call to htpasswd to instruct it to use bcrypt.
