### PR TITLE
Minor Indentation fix - TURN & STUN for calls

### DIFF
--- a/content/ejabberd.md
+++ b/content/ejabberd.md
@@ -243,11 +243,11 @@ your turnserver:
     secret: "your_auth_secret"
     services:
       -
-    host: turn.example.org
+        host: turn.example.org
         type: stun
       -
-    host: turn.example.org
-    type: turn
+        host: turn.example.org
+        type: turn
 ```
 
 And with that, you\'ve successfully setup your ejabberd XMPP server!


### PR DESCRIPTION
Just look at the bottom section. The goal of this is to make it the same as the [original](https://web.archive.org/web/20220515022128/https://landchad.net/ejabberd.html)
 The Hugo version's indentation should work, but it looked off (3 unindented, 1 indented)

Anyway, as minor a PR can be, didn't even use git

P.S. Why change code color from green to white? Green was better imo, it was visual indicator that it is indeed code (white is plain text)