### PR TITLE
cgit: add guide for cloning via HTTPS

### DIFF
--- a/content/cgit.md
+++ b/content/cgit.md
@@ -129,6 +129,38 @@ chmod +x hooks/post-receive
 Next time you push to that repository, the idle time should reset and
 show the correct value.
 
+### Allowing clone via HTTPS
+
+If you want others to be able to clone your git repository, you might
+need to enable the `git://` daemon or give public SSH access, both of
+which have their cons. You can set up your NGINX server to call a git
+subprogram that allows cloning anonymously via HTTP(S).
+
+To do this, add the following lines to your nginx server, above the
+`location @cgit` line we added before:
+
+```nginx
+location ~ /.+/(info/refs|git-upload-pack) {
+    include             fastcgi_params;
+	fastcgi_param       SCRIPT_FILENAME /usr/lib/git-core/git-http-backend;
+	fastcgi_param       PATH_INFO           $uri;
+	fastcgi_param       GIT_HTTP_EXPORT_ALL 1;
+	fastcgi_param       GIT_PROJECT_ROOT    /srv/git;
+	fastcgi_param       HOME                /srv/git;
+	fastcgi_pass        unix:/run/fcgiwrap.socket;
+}
+```
+
+Note: `GIT_PROJECT_ROOT` and `HOME` must point to the location where
+your repositories are stored.
+
+You can also add the `clone-prefix` setting to cgit so the clone URL
+is shown for each repository:
+
+```txt
+clone-prefix=https://git.example.org
+```
+
 ## Contribution
 
 -   Ariel Costas -- [website](https://costas.dev),

--- a/content/cgit.md
+++ b/content/cgit.md
@@ -163,5 +163,4 @@ clone-prefix=https://git.example.org
 
 ## Contribution
 
--   Ariel Costas -- [website](https://costas.dev),
-    [donations](https://costas.dev/donations/)
+-   Ariel Costas -- [website](https://costas.dev)


### PR DESCRIPTION
As commented on #206, I've written an extra section on the cgit guide to allow cloning repositories via HTTPS. I've also removed my donations link since it's a broken link and I don't have a replacement for it.