### PR TITLE
Add shortcode for <mark>ing text and code

### DIFF
--- a/layouts/shortcodes/hl.html
+++ b/layouts/shortcodes/hl.html
@@ -1,0 +1,1 @@
+<mark>{{ .Inner }}</mark>


### PR DESCRIPTION
This allows marking code from within markdown, useful for highlighting
domains inside configuration blocks, like the old website had.

Unless modified via CSS, it will display as black text over yellow
background. However, I wrote a few lines of CSS to make it look like the old version:

```css
mark {
    background: unset;
    color: gold;
    font-weight: bold;
}
```

An example of usage within a markdown file.

```
ssl_certificate /etc/ssl/nginx/{{<hl>}}example.com{{</hl>}};
```