### PR TITLE
Fixed Matrix Element image paths + Added note about configuration for Matrix Synapse

### DIFF
--- a/content/matrix.md
+++ b/content/matrix.md
@@ -114,12 +114,12 @@ an admin.
 register_new_matrix_user -c homeserver.yaml http://localhost:8008
 ```
 
-## Using Matrix with ![Element Matrix logo](pix/element.svg)Element
+## Using Matrix with ![Element Matrix logo](/pix/element.svg)Element
 
 There are many different [clients](https://matrix.org/clients/) that can
 be used on desktops or phones to chat on your Matrix server, but the
 most popular and most widely vetted is ![Element
-logo](pix/element.svg)Element.
+logo](/pix/element.svg)Element.
 
 Get Element to access your Matrix server:
 

--- a/content/matrix.md
+++ b/content/matrix.md
@@ -91,6 +91,7 @@ certbot --nginx -d matrix.example.org
 
 ## Configuration
 
+
 ### Read the config file
 
 The configuration file for Matrix is in
@@ -111,7 +112,23 @@ choices for creating a user, among which will be the ability to make it
 an admin.
 
 ```sh
+cd /etc/matrix-synapse
+
 register_new_matrix_user -c homeserver.yaml http://localhost:8008
+```
+
+### Error Shared secret registration is not enabled
+
+Sometimes the default configuration is not fully setup, so you need
+to add the following the keys to your `homeserver.yaml`:
+
+- `macaroon_secret_key`
+- `registration_shared_secret`
+
+Make sure to restart Matrix Synapse
+
+```sh
+systemctl restart matrix-synapse
 ```
 
 ## Using Matrix with ![Element Matrix logo](/pix/element.svg)Element


### PR DESCRIPTION
- [x] Fixed paths to Element logo images
- [x] Added note about checking and setting the `macaroon_secret_key` and `registration_shared_secret` keys for Matrix