### PR TITLE
Nextcloud: remove nginx pagespeed directive

### DIFF
--- a/content/nextcloud.md
+++ b/content/nextcloud.md
@@ -127,7 +127,6 @@ server {
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
     gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
-    pagespeed off;
     client_body_buffer_size 512k;
     add_header Referrer-Policy                      "no-referrer"   always;
     add_header X-Content-Type-Options               "nosniff"       always;


### PR DESCRIPTION
Removes pagespeed directive from the nextcloud nginx configuration.

Fixes #224.