### PR TITLE
Replaced php7.4-fpm to php-fpm on dokuwiki.md

### DIFF
--- a/content/dokuwiki.md
+++ b/content/dokuwiki.md
@@ -69,7 +69,7 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param REDIRECT_STATUS 200;
-        fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php-fpm.sock;
         # fastcgi_pass unix:/var/run/php5-fpm.sock; #old php version
     }
 }


### PR DESCRIPTION
php-fpm is a symbolic link to whatever is the current version of php. Specifying the symbolic link is preferrable so there is no need to edit the nginx config file whenever php is updated.