### PR TITLE
Updated PHP version on several articles; fixed typo, added firewall command and documentation links on mumble.md

### DIFF
--- a/content/dokuwiki.md
+++ b/content/dokuwiki.md
@@ -90,7 +90,7 @@ certbot --nginx
 Restart nginx and php in order for the changes to take effect.
 
 ```sh
-systemctl restart nginx && systemctl restart php7.4-fpm
+systemctl restart nginx && systemctl restart php8.2-fpm
 ```
 
 Finally, go to `wiki.yourwebsite.com/install.php` to finish the installation process. Read up [the documentation](https://www.dokuwiki.org/installer) in order to understand what each of those itens mean.

--- a/content/mumble.md
+++ b/content/mumble.md
@@ -15,7 +15,7 @@ The server can also be run [behind Tor](https://gitlab.torproject.org/legacy/tra
 
 Mumble has a Debian repository for client and server, however it's very outdated so we are going to build the server instead.
 
-**I suggest to build both binaries on your local machine and [transfer the `mumble-server` to your remote server using `spc`](#extra).**
+**I suggest to build both binaries on your local machine and [transfer the `mumble-server` to your remote server using `scp`](#extra).**
 
 
 Install dependencies:
@@ -64,6 +64,12 @@ Create a folder in `/etc/` move your config files there.
 
 ```sh
 mkdir /etc/mumble && mv mumble-server.ini /etc/mumble
+```
+
+By default, mumble-server uses port 64738, so make sure to open that port on your firewall (if you're using one), or whatever other port you selected on your configuration file. If you're using `ufw` as your firewall, the command is:
+
+```sh
+ufw allow 64738
 ```
 
 Now we can run the server passing the config and a superuser password that can be used to connect and authenticate as an administrator from any client
@@ -115,6 +121,10 @@ Click on `Ok`, select your server from the list and click `Connect`.
 
 **Now you are connected to your very own Mumble server as a SuperUser!**
 
+Now, you will want to setup a regular user to be an administrator of the server. Follow the [official documentation](https://wiki.mumble.info/wiki/Murmurguide#Becoming_Administrator_and_Registering_a_User) in order to do that, it is well-explained, so I won't repeat it here.
+
+Also, you might want to take a look at the [options for your config file](https://wiki.mumble.info/wiki/Murmurguide#Set_Up_Server), since mumble let's you set up a good amount of things, including a server password, a welcome message, and how to make your server public for the whole internet to see.
+
 ---
 
 ## Extra
@@ -124,7 +134,7 @@ Click on `Ok`, select your server from the list and click `Connect`.
 Move your binary to the folder `~` of your remote server.
 
 ```sh
-spc <your_binary> root@<your_server_ip>:~
+scp <your_binary> root@<your_server_ip>:~
 ```
 
 ---

--- a/content/nextcloud.md
+++ b/content/nextcloud.md
@@ -22,10 +22,10 @@ cloud experience (in the likes of Google Services, anyways).
 First, we install the dependencies:
 
 ```sh
-apt install -y nginx python3-certbot-nginx mariadb-server php7.4 php7.4-{fpm,bcmath,bz2,intl,gd,mbstring,mysql,zip,xml,curl}
+apt install -y nginx python3-certbot-nginx mariadb-server php php-{fpm,bcmath,bz2,intl,gd,mbstring,mysql,zip,xml,curl}
 ```
 
-*Optionally*, you can improve the performance of your Nextcloud server by adjusting the child processes that are used to execute PHP scripts. That way, more PHP scripts can be executed at once. Make the following adjustments to `/etc/php/7.4/fpm/pool.d/www.conf`:
+*Optionally*, you can improve the performance of your Nextcloud server by adjusting the child processes that are used to execute PHP scripts. That way, more PHP scripts can be executed at once. Make the following adjustments to `/etc/php/8.2/fpm/pool.d/www.conf`:
 
 ```systemd
 pm = dynamic
@@ -98,7 +98,7 @@ Add the following content [based of Nextcloud's recommendations](https://docs.ne
 
 ```nginx
 upstream php-handler {
-    server unix:/var/run/php/php7.4-fpm.sock;
+    server unix:/var/run/php/php-fpm.sock;
     server 127.0.0.1:9000;
 }
 map $arg_v $asset_immutable {
@@ -216,7 +216,7 @@ chmod -R 755 /var/www/nextcloud
 Start and enable php-fpm and reload nginx:
 
 ```sh
-systemctl enable php7.4-fpm --now
+systemctl enable php8.2-fpm --now
 systemctl reload nginx
 ```
 

--- a/content/rainloop.md
+++ b/content/rainloop.md
@@ -26,7 +26,7 @@ First we will install the required packages for Rainloop with the
 following command:
 
 ```sh
-apt-get install php7.4 php7.4-common php7.4-curl php7.4-xml php7.4-fpm php7.4-json php7.4-dev php7.4-mysql unzip -y
+apt-get install php php-common php-curl php-xml php-fpm php-json php-dev php-mysql unzip -y
 ```
 
 Then we will download the community version of Rainloop, unzip it into
@@ -65,7 +65,7 @@ server {
         fastcgi_index index.php;
         fastcgi_split_path_info ^(.+\.php)(.*)$;
         fastcgi_keep_conn on;
-        fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php-fpm.sock;
         include /etc/nginx/fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
     }

--- a/content/rss-bridge.md
+++ b/content/rss-bridge.md
@@ -25,7 +25,7 @@ setup Fail2Ban. There\'s a great tutorial on how to do this [which can be read h
 Next we\'ll install the required packages:
 
 ```sh
-apt install -y curl unzip nginx certbot php-fpm php-mysql php-cli php7.4-mbstring php7.4-curl php7.4-xml php7.4-sqlite3 php7.4-json
+apt install -y curl unzip nginx certbot php-fpm php-mysql php-cli php-mbstring php-curl php-xml php-sqlite3 php-json
 ```
 
 We now have to create the website configuration file. Create/open the a
@@ -49,7 +49,7 @@ server {
 
     location ~ \.php$ {
             include snippets/fastcgi-php.conf;
-            fastcgi_pass unix:/var/run/php/php7.4-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php-fpm.sock;
     }
 
     location ~ /\.ht {


### PR DESCRIPTION
This commit updates the PHP version on several articles, which is currently 8.2 on Debian.
It also uses symbolic links (such as `php-fpm.sock`) on nginx config files and dependency packages (such as `php-mbstring`) that will always point to the most recent version of PHP, so there is no need to change those once PHP is updated.

On places where the PHP version must be specified, such as the `/etc/php/8.2/` directory and the `php8.2-fpm` systemd service, I have changed the version accordingly.

I believe I have covered every instance of PHP usage on the website, and programs should work fine. If I missed something or made a change that broke the configuration of some program, please let me know.

Additionally, I have fixed a typo on mumble.md, which called the command `scp` as `spc`, added a command to open the mumble port on your firewall and added documentation links for further configuration of the server.

This also fixes #254 and #273.