### PR TITLE
Fixed example mysql config

### DIFF
--- a/content/irc.md
+++ b/content/irc.md
@@ -534,7 +534,7 @@ persistent:
 
 # connection information for MySQL (currently only used for persistent history):
 mysql:
-    enabled: false
+    enabled: true
     host: "localhost"
     port: 3306
     # if socket-path is set, it will be used instead of host:port


### PR DESCRIPTION
Enabling mysql should include setting `mysql: true` in config

I imagine this was probably just a typo


This fixed an issue for me when setting up ergo using this config and running `./ergo run`

```
Config file did not load successfully: You must configure a MySQL server in order to enable persistent history
```


It also matches the recommended config on ergo's docs
https://github.com/ergochat/ergo/blob/stable/docs/MANUAL.md#persistent-history-with-mysql

Might also be worth mentioning how to set up the mysql database, or could link to [ergo's docs](https://github.com/ergochat/ergo/blob/stable/docs/MANUAL.md#persistent-history-with-mysql) which has a few lines for how to do it.