### PR TITLE
Added ssh configuration overriding warning

### DIFF
--- a/content/sshkeys.md
+++ b/content/sshkeys.md
@@ -123,6 +123,22 @@ Once we\'ve done that, we will reload our SSH daemon:
 systemctl reload sshd
 ```
 
+### **Warning:**
+
+If you are using Debian 12, it is possible that your ssh configuration
+will be overridden by the default configuration added when creating
+the VPS, which will leave you vulnerable to brute force attacks. To
+prevent this, remove the configuration file using the following
+command:
+
+```sh
+rm /etc/ssh/sshd_config/50-cloud-init.conf
+```
+
+Also verify that the `/etc/ssh/ssh_config.d/` path is empty. If not,
+make sure that the configuration files in that folder are not
+overriding yours.
+
 ### We\'re done!
 
 Now you can log in quickly and password-less-ly to your server, despite

--- a/content/sshkeys.md
+++ b/content/sshkeys.md
@@ -125,7 +125,7 @@ systemctl reload sshd
 
 ### **Warning:**
 
-If you are using Debian 12, it is possible that your ssh configuration
+It is possible that your ssh configuration
 will be overridden by the default configuration added when creating
 the VPS, which will leave you vulnerable to brute force attacks. To
 prevent this, remove the configuration file using the following


### PR DESCRIPTION
Added a warning to the "Log on with SSH Keys" post to prevent be exposed to brute force attacks.

# Context

~Starting with Debian 12 bookworm~ For Debian 11 and 12 there is a new configuration file that is added by default when the VPS is created as part of the initial configuration done by Vultr (and possibly other cloud providers do the same). The file is located in the path /etc/ssh/ssh_config.d/50-cloud-init.conf, and said file contains the line:

```sh
PasswordAuthentication yes
```

which is risky for the security of the system, since it allows login using a password and leaving the computer vulnerable to brute force attacks.

![image](https://github.com/LukeSmithxyz/landchad/assets/32922313/1e0a1fd5-b8aa-4859-bb87-e8ef1d2c76a3)


fixes #303 

