### PR TITLE
Improve the Monero Node and I2P guides

### DIFF
--- a/content/i2p.md
+++ b/content/i2p.md
@@ -15,9 +15,24 @@ There are 2 main I2P implementations, I2P and i2pd, we are using i2pd in this gu
 
 ### Installing I2P
 
-i2pd is in most repos, in debian/ubuntu you can install it simply with
+We need to [add the i2pd repos to our system](https://repo.i2pd.xyz/) to get the latest version of i2pd:
+
+Install apt-transport-https and gpg package:
 
 ```sh
+apt install apt-transport-https gpg
+```
+
+Automatically add the repository with a script:
+
+```sh
+wget -q -O - https://repo.i2pd.xyz/.help/add_repo | bash -s -
+```
+
+After that you can install i2pd as any other software package:
+
+```sh
+apt update
 apt install i2pd
 ```
 
@@ -46,7 +61,7 @@ keys = example.dat
 
 If you run `i2pd` with the configuration above, it will generate a random private key (`example.dat`) for your website in `example.dat` with a matching address made up of 52 random characters, derived from this same key.
 
-If you instead pre-generate a private key for your website, you can use  brute-force computation to make a "vanity" address, such as the following:
+If you instead pre-generate a private key for your website, you can use brute-force computation to make a "vanity" address, such as the following:
 ```
 {{<hl>}}chad{{</hl>}}aor3jc08ht340c30mg5cf340j395gj095kuazj5tokipr34f.32.i2p
 ```

--- a/content/i2p.md
+++ b/content/i2p.md
@@ -58,7 +58,7 @@ If you run `i2pd` with the configuration above, it will generate a random privat
 
 If you instead pre-generate a private key for your website, you can use brute-force computation to make a "vanity" address, such as the following:
 ```
-chadaor3jc08ht340c30mg5cf340j395gj095kuazj5tokipr34f.32.i2p
+{{<hl>}}chad{{</hl>}}aor3jc08ht340c30mg5cf340j395gj095kuazj5tokipr34f.32.i2p
 ```
 
 To accomplish this, a set of tools named `i2pd-tools` can be installed.
@@ -81,7 +81,7 @@ make -j$(nproc)
 
 This will build a variety of useful tools for i2p, with `vain` being the command of interest to generate an address:
 ```sh
-./vain chad
+./vain {{<hl>}}chad{{</hl>}}
 ```
 This command will begin running and output a new set of private keys named `private.dat` to the same directory it's ran from. Copy this file to your i2p configuration and you'll have your vanity address:
 
@@ -94,7 +94,7 @@ cp private.dat /var/lib/i2pd/example.dat
 I2P has various **registrars** that let users link their long I2P addresses to shorter, more memorable ones, like `example.i2p`. To actually register your site on one of these registrars, you will need an **authentication string.** Luckily, `i2pd-tools` includes such a tool in their repository:
 
 ```sh
-./regaddr private.dat example.2ip > auth_string.txt
+./regaddr private.dat {{<hl>}}example.2ip{{</hl>}} > {{<hl>}}auth_string.txt{{</hl>}}
 ```
 
 The command above will save the string to a file named `auth_string.txt`. You will have to place the text contained in that file on a registration page like [http://reg.i2p/add](http://reg.i2p/add) or [http://stats.i2p/i2p/addkey.html](http://stats.i2p/i2p/addkey.html).
@@ -121,7 +121,7 @@ From here, the steps are almost identical to setting up a normal website configu
 ```nginx
 server {
 	listen 127.0.0.1:8080 ;
-	root /var/www/example ;
+	root /var/www/{{<hl>}}example{{</hl>}} ;
 	index index.html ;
 }
 ```

--- a/content/i2p.md
+++ b/content/i2p.md
@@ -76,7 +76,7 @@ sh dependencies.sh
 
 Then compile using the `make` command:
 ```sh
-make -j$(nproc)
+make
 ```
 
 This will build a variety of useful tools for i2p, with `vain` being the command of interest to generate an address:

--- a/content/i2p.md
+++ b/content/i2p.md
@@ -11,7 +11,7 @@ Now you have a website, why not offer it in a private alternative such as the In
 
 ## Setting up I2P
 
-There are 2 main I2P implementations, I2P and i2pd, we are using i2pd in this guide because it\'s easier to use in servers.
+There are 2 main I2P implementations, I2P and i2pd, we are using i2pd in this guide because it's easier to use on servers.
 
 ### Installing I2P
 
@@ -38,16 +38,9 @@ apt install i2pd
 
 ### Enabling I2P
 
-We are going to create a user for i2pd, because i2pd finds the configuration files in its home directory. And it\'s easier (and more tidy) to have it in a separate user:
+Next we have to configure the i2pd daemon, the configuration is located at `/etc/i2pd/`.
 
-```sh
-useradd -m i2p -s /bin/bash
-su -l i2p
-mkdir ~/.i2pd
-cd ~/.i2pd
-```
-
-Now that you\'re in \~/.i2pd, you have to create a file named \"tunnels.conf\". Which is the config file for every hidden service you\'re offering over I2P, the content should be like this:
+Edit the `tunnels.conf` file and add the following configuration to the file:
 
 ```systemd
 [example]
@@ -57,13 +50,15 @@ port = 8080
 keys = example.dat
 ```
 
+You can comment or remove the tunnels that are added by default in the configuration file.
+
 #### Optional: Generating a Vanity Address
 
-If you run `i2pd` with the configuration above, it will generate a random private key (`example.dat`) for your website in `example.dat` with a matching address made up of 52 random characters, derived from this same key.
+If you run `i2pd` with the configuration above, it will generate a random private key (`example.dat`) for your website at `/var/lib/i2pd/` with a matching address made up of 52 random characters, derived from this same key.
 
 If you instead pre-generate a private key for your website, you can use brute-force computation to make a "vanity" address, such as the following:
 ```
-{{<hl>}}chad{{</hl>}}aor3jc08ht340c30mg5cf340j395gj095kuazj5tokipr34f.32.i2p
+chadaor3jc08ht340c30mg5cf340j395gj095kuazj5tokipr34f.32.i2p
 ```
 
 To accomplish this, a set of tools named `i2pd-tools` can be installed.
@@ -86,12 +81,12 @@ make -j$(nproc)
 
 This will build a variety of useful tools for i2p, with `vain` being the command of interest to generate an address:
 ```sh
-./vain {{<hl>}}chad{{</hl>}}
+./vain chad
 ```
 This command will begin running and output a new set of private keys named `private.dat` to the same directory it's ran from. Copy this file to your i2p configuration and you'll have your vanity address:
 
 ```sh
-cp private.dat /home/i2p/.i2pd/example.dat
+cp private.dat /var/lib/i2pd/example.dat
 ```
 
 #### Optional: Authentication Strings for Registrars
@@ -99,14 +94,14 @@ cp private.dat /home/i2p/.i2pd/example.dat
 I2P has various **registrars** that let users link their long I2P addresses to shorter, more memorable ones, like `example.i2p`. To actually register your site on one of these registrars, you will need an **authentication string.** Luckily, `i2pd-tools` includes such a tool in their repository:
 
 ```sh
-./regaddr private.dat {{<hl>}}example.2ip{{</hl>}} > {{<hl>}}auth_string.txt{{</hl>}}
+./regaddr private.dat example.2ip > auth_string.txt
 ```
 
 The command above will save the string to a file named `auth_string.txt`. You will have to place the text contained in that file on a registration page like [http://reg.i2p/add](http://reg.i2p/add) or [http://stats.i2p/i2p/addkey.html](http://stats.i2p/i2p/addkey.html).
 
 ### Getting your I2P Hostname
 
-Then, run `/usr/sbin/i2pd --daemon` to start i2pd and we can retreive our I2P hostname.
+Then, run the command `systemctl start i2pd` to start i2pd and `systemctl enable i2pd` to enable i2pd at startup, this will automatically generate our I2P hostname which we will now see.
 
 This can be done in lynx or a command-line browser by going to `http://127.0.0.1:7070/?page=i2p_tunnels` to get your I2P hostname.
 
@@ -114,28 +109,26 @@ You can also run these commands to find your hostname:
 
 ```sh
 printf "%s.b32.i2p
-" $(head -c 391 /home/i2p/.i2pd/example.dat |sha256sum|xxd -r -p | base32 |sed s/=//g | tr A-Z a-z)
+" $(head -c 391 /var/lib/i2pd/example.dat | sha256sum | xxd -r -p | base32 | sed s/=//g | tr A-Z a-z)
 ```
 
 *(If you've generated your own keys to obtain a vanity address, now's a good time to make sure i2pd is properly reading those keys by verifying the address is the same as the one generated with the `vain` command.)*
 
 ## Adding the Nginx Config
 
-From here, the steps are almost identical to setting up a normal websitenconfiguration file. Follow the steps as if you were making a new website on the webserver [tutorial](/basic/nginx) up until the server block of code. Instead, paste this:
+From here, the steps are almost identical to setting up a normal website configuration file. Follow the steps as if you were making a new website on the webserver [tutorial](/basic/nginx) up until the server block of code. Instead, paste this:
 
 ```nginx
 server {
 	listen 127.0.0.1:8080 ;
-	root /var/www/{{<hl>}}example{{</hl>}} ;
+	root /var/www/example ;
 	index index.html ;
 }
 ```
 
 #### Clarifications
 
-####
-
-Nginx will listen in port 8080, but i2pd will forward your port 8080 to the i2p site port 80. This way you don\'t have to deal with server names or anything like that.
+Nginx will listen on port 8080, but i2pd will forward your port 8080 to the i2p site port 80. This way you don't have to deal with server names or anything like that.
 
 From here we are almost done, all we have to do is enable the site and reload nginx which is also covered in [the webserver tutorial](nginx.html#enable).
 
@@ -144,7 +137,9 @@ From here we are almost done, all we have to do is enable the site and reload ng
 Make sure to update I2P on a regular basis by running:
 
 ```sh
-apt update && apt install i2pd
+apt update && apt upgrade
 ```
 
-**Contributor** - [qorg11](https://qorg11.net)
+**Contributors** 
+- [qorg11](https://qorg11.net)
+- [David Uhden](https://github.com/daviduhden)

--- a/content/monerod.md
+++ b/content/monerod.md
@@ -47,6 +47,9 @@ data-dir={{<hl>}}/var/lib/monero{{</hl>}}
 log-file={{<hl>}}/var/log/monero/monero.log{{</hl>}}
 log-level=0
 
+# Slow but reliable db writes
+db-sync-mode=safe
+
 # 1048576 kB/s == 1GB/s; a raise from default 2048 kB/s; contribute more to p2p network
 limit-rate-up=1048576
 limit-rate-down=1048576

--- a/content/monerod.md
+++ b/content/monerod.md
@@ -31,6 +31,8 @@ tar -xvjf linux64
 mv linux64/monero* /usr/bin/
 ```
 
+If the hardware you are using is not based on the amd64 architecture (like a Raspberry Pi), the monero project also [offers binaries](https://www.getmonero.org/downloads/) for other architectures on Linux, to download and install them simply change the last part of the link (linux64) and the archive name, e.g. for arm64 (linuxarm8). The fastest way to find out which one to use in Debian is with the `dpkg --print-architecture` command.
+
 ## Configuration
 
 By default, Monero comes with no sample configuration files. Create one in `/etc/monerod.conf` using a text editor, and enter the following details:

--- a/content/monerod.md
+++ b/content/monerod.md
@@ -122,9 +122,9 @@ Edit `/etc/tor/torrc` and add the following:
 HiddenServiceDir /var/lib/tor/monerod
 
 # For wallets connecting over RPC:
-HiddenServicePort 18081 127.0.0.1:18081
+HiddenServicePort 18081 127.0.0.1:18181
 # For other nodes:
-HiddenServicePort 18083 127.0.0.1:18083
+HiddenServicePort 18083 127.0.0.1:18183
 ```
 
 Now restart Tor:
@@ -145,13 +145,13 @@ Edit `tunnels.conf` (Which may be located in `/home/i2p/.i2pd/` if you followed 
 [monerod]
 type = http
 host = 127.0.0.1
-port = 18083
+port = 18283
 keys = monerod.dat
 
 [monerod-rpc]
 type = http
 host = 127.0.0.1
-port = 18081
+port = 18281
 keys = monerod-rpc.dat
 ```
 
@@ -171,13 +171,13 @@ printf "%s.b32.i2p
 Then, in `/etc/monerod.conf`, add the following:
 
 ```sh
-# I2P config
-tx-proxy=i2p,127.0.0.1:4447
-anonymous-inbound={{<hl>}}your-i2p-address-here.b32.i2p{{</hl>}}:80,127.0.0.1:18083,16 # Maximum 16 simultaneous connections
-
 # Tor config
 tx-proxy=tor,127.0.0.1:9050,10
-anonymous-inbound={{<hl>}}your-tor-address-here.onion{{</hl>}}:18083,127.0.0.1:18083,16
+anonymous-inbound={{<hl>}}your-tor-address-here.onion{{</hl>}}:18083,127.0.0.1:18183,16
+
+# I2P config
+tx-proxy=i2p,127.0.0.1:4447
+anonymous-inbound={{<hl>}}your-i2p-address-here.b32.i2p{{</hl>}}:80,127.0.0.1:18283,16 # Maximum 16 simultaneous connections
 ```
 
 ## Running the Node

--- a/content/monerod.md
+++ b/content/monerod.md
@@ -144,7 +144,7 @@ cat /var/lib/tor/monerod/hostname
 
 ### I2P
 
-Edit `tunnels.conf` (Which may be located in `/home/i2p/.i2pd/` if you followed [this](/i2p) guide) and add the following tunnels:
+Edit `tunnels.conf` (Which may be located in `/etc/i2pd/` if you followed [this](/i2p) guide) and add the following tunnels:
 
 ```systemd
 [monerod]


### PR DESCRIPTION
**Changes in the Monero guide:**

- **Use different ports for the proxies to the hidden services in Tor and I2P.** 
  - Reason: Otherwise, it is impossible for the node to work, and you will always get the error “Failed to bind IPv4 (set to required)”.
  - Note: With this change, you can start the `monerod` daemon with the configuration for Tor and I2P added. I tested this configuration on a public node that I hosted on the clearnet, in Tor, and in I2P using the guide's configuration. However, I couldn't connect to the node through Tor and I2P to synchronize the wallet with the blockchain. _Undoubtedly, the Monero node is one of the services that has given me more problems when hosting it._

- **Add instructions for installation on other architectures.**

- **Set the "db-sync-mode" option to "safe".** 
  - Reason: The default "fast" setting can corrupt the blockchain database in case of a power outage or other type of system crash. It is always better to use the "safe" option, especially if you use your own hardware to host the node.

**Changes in the I2P guide:**

- **Use the i2pd community repository to get the latest version.**

- **No need to create a new user for this service.** 
  - Reason 1: The system automatically creates a new user that will be used to run the daemon when installing the package.
  - Reason 2: i2pd does not look for the configuration files by default in the home directory of the i2pd user but rather in `/etc/i2pd/`.
