### PR TITLE
Corrections to the tor and email guides

### DIFF
--- a/content/mail/security.md
+++ b/content/mail/security.md
@@ -42,18 +42,20 @@ Go down to the `# Mail servers` line and paste this:
     enabled  = true
     port     = smtp,ssmtp,submission
     filter   = postfix
-    logpath  = /var/log/mail.log
+    logpath = %(postfix_log)s
+    backend = systemd
 
 
     [sasl]
 
     enabled  = true
     port     = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
-    filter   = postfix-sasl
+    filter   = postfix[mode=auth]
     # You might consider monitoring /var/log/mail.warn instead if you are
     # running postfix since it would provide the same log lines at the
     # "warn" level but overall at the smaller filesize.
-    logpath  = /var/log/mail.warn
+    logpath = %(postfix_log)s
+    backend = systemd
     maxretry = 1
     bantime  = 21600
 
@@ -62,7 +64,8 @@ Go down to the `# Mail servers` line and paste this:
     enabled = true
     port    = smtp,ssmtp,submission,imap2,imap3,imaps,pop3,pop3s
     filter  = dovecot
-    logpath = /var/log/mail.log
+    logpath = %(dovecot_log)s
+    backend = systemd
 
 This will only grant 2 login attempts and then block the requester for 6 hours. Now restart `fail2ban`:
 

--- a/content/tor.md
+++ b/content/tor.md
@@ -23,12 +23,12 @@ system](https://support.torproject.org/apt/tor-deb-repo/) to get the
 latest version of Tor:
 
     apt install -y apt-transport-https gpg
-    echo "deb     [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $(lsb_release -cs) main
-    deb-src [signed-by=/usr/share/keyrings/tor-archive-keyring.gpg] https://deb.torproject.org/torproject.org $(lsb_release -cs) main" > /etc/apt/sources.list.d/tor.list
+    echo "deb     [signed-by=/usr/share/keyrings/deb.torproject.org-keyring.gpg] https://deb.torproject.org/torproject.org $(lsb_release -cs) main
+    deb-src [signed-by=/usr/share/keyrings/deb.torproject.org-keyring.gpg] https://deb.torproject.org/torproject.org $(lsb_release -cs) main" > /etc/apt/sources.list.d/tor.list
 
 Then we need to add the GPG keys to our keyring:
 
-    curl -s https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor > /usr/share/keyrings/tor-archive-keyring.gpg
+    curl -s https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --dearmor > /usr/share/keyrings/deb.torproject.org-keyring.gpg
 
 Now install Tor:
 


### PR DESCRIPTION
The Tor guide makes people download a gpg key to `/usr/share/keyrings/tor-archive-keyring.gpg` and request signatures from that key for the repository. It also recommends installing the `deb.torproject.org-keyring` package, which should update this key before it expires.

However, this package actually writes to `/usr/share/keyrings/deb.torproject.org-keyring.gpg`. This causes people to get errors when the key they downloaded expires, and the configuration is still looking at that key, not the one that is automatically updated.

This pull request corrects this issue, which has already been fixed in the official documentation of the Tor project [^1].

On the other hand, the Fail2Ban configuration in the hardening section of the guide to setting up a email server will not work on Debian 12 or other recent Linux distributions that use systemd for the following reasons:

1. The Postfix SASL and RBL filters have been merged with the Postfix filter and no longer exist separately in Fail2Ban [^2].

2. In modern systemd-based distributions, such as recent versions of Ubuntu, Debian, Archlinux, RHEL, Fedora, etc, services such as SSH, Postfix and Dovecot are logged in the systemd journal [^3].

[^1]: [Issue 368](https://gitlab.torproject.org/tpo/web/support/-/issues/368)
[^2]: [NethServer Forum](https://community.nethserver.org/t/fail2ban-postfix-sasl-and-postfix-rbl-not-enabling-or-running/14607/4)
[^3]: [Issue 3292](https://github.com/fail2ban/fail2ban/issues/3292)
